### PR TITLE
allow only https requests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+* Wed Nov 13 2019 Tadeusz Wawszczak <tadeusz.wawszczak@openx.com> 2.1.3
+- use only https
+
 * Mon Oct 8 2018 Yunjia Lu <yunjia.lu@openx.com> 2.1.2
 - Add trade desk id support
 - Clarify private market DFP targeting

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -31,7 +31,7 @@
 | Bid Type (Gross / Net) | Net |
 | GAM Key (Open Market) | ix_ox_om |
 | GAM Key (Private Market) | ix_ox_pm |
-| Ad Server URLs | http(s)://valid_host_name/w/1.0/arj? |
+| Ad Server URLs | https://valid_host_name/w/1.0/arj? |
 | Slot Mapping Sytle (Size / Multiple Sizes / Slot) | Multiple Sizes |
 | Request Architecture (MRA / SRA) | SRA |
  
@@ -48,7 +48,7 @@
  
 ### Example
 ```javascript
-http(s)://valid_host_name/w/1.0/arj?auid=54321%2C12345&aus=300x250%2C300x600%7C300x600&bc=hb_ix_2.1.2&be=1&ju=http%3A%2F%2Flocalhost%3A5837%2Fpublic%2Fdebugger%2Fadapter-debugger.html&jr=http%3A%2F%2Flocalhost%3A5837%2Fpublic%2Fdebugger%2Fadapter-debugger.html&ch=UTF-8&tz=420&res=1440x900&tws=1303x347&ifr=1&callback=window.headertag.OpenXHtb.adResponseCallbacks._Bo02nxzC&cache=1539218162700&gdpr_consent=TEST_GDPR_CONSENT_STRING&gdpr=1
+https://valid_host_name/w/1.0/arj?auid=54321%2C12345&aus=300x250%2C300x600%7C300x600&bc=hb_ix_2.1.3&be=1&ju=http%3A%2F%2Flocalhost%3A5837%2Fpublic%2Fdebugger%2Fadapter-debugger.html&jr=http%3A%2F%2Flocalhost%3A5837%2Fpublic%2Fdebugger%2Fadapter-debugger.html&ch=UTF-8&tz=420&res=1440x900&tws=1303x347&ifr=1&callback=window.headertag.OpenXHtb.adResponseCallbacks._Bo02nxzC&cache=1539218162700&gdpr_consent=TEST_GDPR_CONSENT_STRING&gdpr=1
 ```
  
 ## Bid Response Information

--- a/open-x-htb-exports.js
+++ b/open-x-htb-exports.js
@@ -1,6 +1,6 @@
 shellInterface.OpenXHtb = {
     adResponseCallbacks: {},
-    version: '2.1.2'
+    version: '2.1.3'
 };
 
 //? if(FEATURES.GPT_LINE_ITEMS) {

--- a/open-x-htb-system-tests.js
+++ b/open-x-htb-system-tests.js
@@ -43,7 +43,7 @@ function validateBidRequest(request) {
     // Check query string parameters.
     expect(request.query.auid).toBe('54321,12345');
     expect(request.query.aus).toBe('300x250,300x600|300x600');
-    expect(request.query.bc).toBe('hb_ix_2.1.2');
+    expect(request.query.bc).toBe('hb_ix_2.1.3');
     expect(request.query.be).toBe('1');
 }
 

--- a/open-x-htb.js
+++ b/open-x-htb.js
@@ -433,7 +433,7 @@ function OpenXHtb(configs) {
             configs.version,
             configs.endPointName
         ]);
-        __baseBeaconUrl = Network.buildUrl( 'https://' + configs.host, [
+        __baseBeaconUrl = Network.buildUrl('https://' + configs.host, [
             configs.medium,
             configs.version,
             'bo'

--- a/open-x-htb.js
+++ b/open-x-htb.js
@@ -386,7 +386,7 @@ function OpenXHtb(configs) {
             partnerId: 'OpenXHtb',
             namespace: 'OpenXHtb',
             statsId: 'OPNX',
-            version: '2.1.2',
+            version: '2.1.3',
             targetingType: 'slot',
             enabledAnalytics: {
                 requestTime: true
@@ -428,12 +428,12 @@ function OpenXHtb(configs) {
         configs.charset = configs.charset || 'UTF-8';
         configs.bidderCode = configs.bidderCode || 'hb_ix';
 
-        __baseAdRequestUrl = Network.buildUrl(Browser.getProtocol() + '//' + configs.host, [
+        __baseAdRequestUrl = Network.buildUrl('https://' + configs.host, [
             configs.medium,
             configs.version,
             configs.endPointName
         ]);
-        __baseBeaconUrl = Network.buildUrl(Browser.getProtocol() + '//' + configs.host, [
+        __baseBeaconUrl = Network.buildUrl( 'https://' + configs.host, [
             configs.medium,
             configs.version,
             'bo'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "self-serve-partners-template",
-  "version": "1.0.0",
+  "version": "2.1.3",
   "description": "A complete self-serve partner development package for Index Exchange's wrapper.",
   "private": true,
   "author": "Index Exchange",


### PR DESCRIPTION
Force that `adRequestUrl` and `beaconUrl` are always secure.

Internal OpenX ticket: OMKT-293